### PR TITLE
Fix: Always return false when likelihood is zero

### DIFF
--- a/packages/@dicebear/core/src/utils/prng.ts
+++ b/packages/@dicebear/core/src/utils/prng.ts
@@ -38,7 +38,7 @@ export function create(seed: string = ''): Prng {
     seed,
     next,
     bool(likelihood: number = 50) {
-      return integer(0, 100) <= likelihood;
+      return integer(1, 100) <= likelihood;
     },
     integer(min: number, max: number) {
       return integer(min, max);


### PR DESCRIPTION
I noticed that sometimes, even when the probability of an option was zero, it would show up from time to time.

The bug was coming from `prng.bool()`, since `integer(0, 100)` would return a random value **including** 0 or 100. This means that even when the likelihood was 0, there was a 1 in 101 chance of returning true.

My PR fix this by changing the `integer` call from `integer(0, 100)` to `integer(1, 100)`, this way, If `likelihood` is 0, it'll always return false.
This also aligns the likelihood with the probability, meaning that a likelihood of 1 has a 1 in 100 chance, instead of 1 in 101 (since 0 was included).